### PR TITLE
Main Menu updates and Menu Bar implementation:

### DIFF
--- a/app.go
+++ b/app.go
@@ -9,15 +9,17 @@ type AppI interface{}
 type MiniAppI interface{}
 
 var (
-	MasterWidth     = 840
-	MasterHeight    = 480
 	FullHeight      float32
-	MainMenuWidth   = float32(MasterWidth / 3)
-	AppsWindowWidth = float32(MasterWidth) - MainMenuWidth
+	FullWidth       float32
+	MainMenuWidth   float32
+	AppsWindowPosX  int
+	AppsWindowWidth float32
+	isMenuToggled   = true
+	MenuBarHeight   = float32(23)
 	titleFont       *giu.FontInfo
 )
 
-// AppsS - The struct for the Menu
+// AppsS - The struct of the Menu
 // AppsI - The AppsList[] as an Interface (to be used with RangeBuilder() as values param)
 var (
 	AppsI = make([]interface{}, len(AppsS.AppsList))
@@ -43,7 +45,25 @@ var (
 				Active: false,
 				MiniApps: []MiniApp{
 					{
-						Name:   "English Explicative Dictionary",
+						Name:   "English",
+						Active: false,
+					},
+				},
+			},
+			{
+				Name:   "Text Handler",
+				Active: false,
+				MiniApps: []MiniApp{
+					{
+						Name:   "Bash Console",
+						Active: false,
+					},
+					{
+						Name:   "JSON Formatter",
+						Active: false,
+					},
+					{
+						Name:   "Text Editor",
 						Active: false,
 					},
 				},
@@ -52,7 +72,6 @@ var (
 	}
 )
 
-// Apps / TODO: Think of a way to work with structs rather than variables
 type Apps struct {
 	AppsList []App
 }
@@ -68,79 +87,126 @@ type MiniApp struct {
 	Active bool
 }
 
+// ConditionedArrowBtn - is used to swap directions of the arrow after each click
+func ConditionedArrowBtn() giu.Widget {
+	var arrowBtn *giu.ArrowButtonWidget
+	if isMenuToggled {
+		arrowBtn = giu.ArrowButton("close menu", giu.DirectionLeft).OnClick(func() {
+			isMenuToggled = false
+		})
+	} else {
+		arrowBtn = giu.ArrowButton("open menu", giu.DirectionRight).OnClick(func() {
+			isMenuToggled = true
+		})
+	}
+	return arrowBtn
+}
+
 func loop() {
 
 	size := giu.Context.GetPlatform().DisplaySize()
+	FullWidth = size[0]
 	FullHeight = size[1]
 
-	if int(size[0]) >= 840 {
-		MainMenuWidth = size[0] / 5
-		AppsWindowWidth = size[0] - MainMenuWidth
+	// For sizes bigger than 990px use responsive width
+	// If the Main Menu is closed, then stretch Apps Window to full width
+	if int(size[0]) >= 990 {
+		MainMenuWidth = size[0] / 4
+		AppsWindowPosX = int(MainMenuWidth)
+	} else {
+		MainMenuWidth = 250
+		AppsWindowPosX = 250
 	}
+	if !isMenuToggled {
+		AppsWindowWidth = FullWidth
+		AppsWindowPosX = 0
+		MainMenuWidth = 0
+	}
+	AppsWindowWidth = FullWidth - MainMenuWidth
 
-	//
+	// Create a list of interfaces converted from struct
 	for i := range AppsI {
 		AppsI[i] = AppI(AppsS.AppsList[i])
 	}
-	// The app consists of 2 main windows:
-	// "Main Menu" and "Apps Layout"
-	giu.Window("Main Menu").
-		// Size = LHN Menu like size and position
-		Size(MainMenuWidth, FullHeight).
+
+	giu.Window("Menu Bar").
 		Pos(0, 0).
 		Flags(
 			giu.WindowFlagsNoMove |
 				giu.WindowFlagsNoResize |
 				giu.WindowFlagsNoTitleBar,
-		).
-		Layout(
-			giu.Child().
-				Border(true).
-				Layout(
-					// This is the Title of the Main Menu. set Text Color to Cyan rgba(0, 255, 255, 255)
-					// Also, use the titleFont of 28px sans
-					giu.Style().
-						SetColor(giu.StyleColorText, color.RGBA{G: 255, B: 255, A: 255}).
-						To(
-							giu.Label("Main Menu").Wrapped(true).Font(titleFont),
-						),
-					giu.Separator(),
-					giu.TreeNode("Apps").
-						Flags(giu.TreeNodeFlagsCollapsingHeader).
-						Layout(
-							// This is where the Main Menu items is generated
-							giu.RangeBuilder("Menu", AppsI, func(i int, v interface{}) giu.Widget {
-								currApp := &AppsS.AppsList[i]
-								MiniAppsI := make([]interface{}, len(currApp.MiniApps))
-								for i := range MiniAppsI {
-									MiniAppsI[i] = MiniAppI(currApp.MiniApps[i])
-								}
-								return giu.TreeNode(currApp.Name).
-									Layout(
-										// This is where the Sub Menu for every Menu Item will be generated
-										giu.RangeBuilder("Sub Menu", MiniAppsI, func(j int, v interface{}) giu.Widget {
-											currMiniApp := &currApp.MiniApps[j]
-											return giu.Row(
-												giu.Checkbox("", &currMiniApp.Active).
-													OnChange(func() {
-														currMiniApp.Active = !currMiniApp.Active
-													}),
-												giu.Selectable(currMiniApp.Name).
-													OnClick(func() {
-														currMiniApp.Active = !currMiniApp.Active
-													}).
-													Selected(currMiniApp.Active),
-											)
-										}),
-									)
-							}),
-						),
-				),
-		)
+		).Layout(
+		giu.MainMenuBar().Layout(
+			ConditionedArrowBtn(),
+		),
+	)
 
-	giu.Window("Apps Layout").
-		Size(AppsWindowWidth, FullHeight).
-		Pos(MainMenuWidth, 0).
+	// The app consists of 2 main windows:
+	// "Main Menu" and "Apps Layout"
+	if isMenuToggled {
+		giu.Window("Main Menu").
+			// Size = LHN Menu-like size and position
+			Size(MainMenuWidth, FullHeight-MenuBarHeight).
+			Pos(0, MenuBarHeight).
+			Flags(
+				giu.WindowFlagsNoMove |
+					giu.WindowFlagsNoResize |
+					giu.WindowFlagsNoTitleBar,
+			).
+			Layout(
+				giu.Child().
+					Border(true).
+					Layout(
+						// This is the Title of the20 Main Menu. set Text Color to Cyan rgba(0, 255, 255, 255)
+						// Also, use the titleFont of 28px sans
+						giu.Row(
+							giu.Style().
+								SetColor(giu.StyleColorText, color.RGBA{G: 255, B: 255, A: 255}).
+								To(
+									giu.Label("Main Menu").Wrapped(true).Font(titleFont),
+								),
+						),
+						giu.Separator(),
+						// LAYOUT Menu
+						giu.TreeNode("Layout").
+							Flags(giu.TreeNodeFlagsCollapsingHeader).
+							Layout(giu.Label("test")),
+
+						// APPS Menu
+						giu.TreeNode("Apps").
+							Flags(giu.TreeNodeFlagsCollapsingHeader).
+							Layout(
+								// This is where the Main Menu items is generated
+								giu.RangeBuilder("Menu", AppsI, func(i int, v interface{}) giu.Widget {
+									currApp := &AppsS.AppsList[i]
+									MiniAppsI := make([]interface{}, len(currApp.MiniApps))
+									for i := range MiniAppsI {
+										MiniAppsI[i] = MiniAppI(currApp.MiniApps[i])
+									}
+									return giu.TreeNode(currApp.Name).
+										Flags(giu.TreeNodeFlagsSpanFullWidth).
+										Layout(
+											// This is where the Sub Menu for every Menu Item will be generated
+											giu.RangeBuilder("Sub Menu", MiniAppsI, func(j int, v interface{}) giu.Widget {
+												currMiniApp := &currApp.MiniApps[j]
+												return giu.Row(
+													giu.Checkbox("", &currMiniApp.Active),
+													giu.Selectable(currMiniApp.Name).
+														OnClick(func() {
+															currMiniApp.Active = !currMiniApp.Active
+														}).
+														Selected(currMiniApp.Active),
+												)
+											}),
+										)
+								}),
+							),
+					),
+			)
+	}
+	giu.Window("Apps").
+		Size(AppsWindowWidth, FullHeight-MenuBarHeight).
+		Pos(float32(AppsWindowPosX), MenuBarHeight).
 		Flags(
 			giu.WindowFlagsNoMove |
 				giu.WindowFlagsNoResize |
@@ -152,12 +218,12 @@ func loop() {
 }
 
 func main() {
-	// Change the default font to sans and of 20 pixels height
-	giu.SetDefaultFont("Sans.ttf", 15)
+	// Change the default font to sans and of 18 pixels height
+	giu.SetDefaultFont("Sans.ttf", 18)
 
-	// change titleFont to look larger
+	// Change titleFont to look larger
 	titleFont = giu.AddFont("Sans.ttf", 28)
 
-	win := giu.NewMasterWindow("Universal App", MasterWidth, MasterHeight, giu.MasterWindowFlagsMaximized)
+	win := giu.NewMasterWindow("Universal App", 960, 640, giu.MasterWindowFlagsMaximized)
 	win.Run(loop)
 }


### PR DESCRIPTION
Main Menu updates and Menu Bar implementation:
  - Refactored code regarding Apps and Main Menu windows sizing and positioning
    - Above 990px, the Main Menu is responsive to the width of the Master Window based on Context.GetPlatform().DisplaySize()
    - Below 990px, the Main Menu becomes static and has 250px width.
    - Removed redundant variables
  - Implemented Menu Bar:
    - Currently there is only one item, which contains the functionality of hiding the Main Menu window:
      - Based on a dynamically adapted ArrowButton (ConditionedArrowBtn()), The Main Menu window can be hidden, extending the Apps window to Full Width
  - Updated Master Window width and height.
  - Updated README.md file